### PR TITLE
Move the --cf-account-id flag to the worker subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,9 +22,7 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfAPITokenFlag, CfAPITokenFlag, "", "Cloudflare API token")
-	rootCmd.PersistentFlags().StringVar(&cfAccountIDFlag, CfAccountIDFlag, "", "Cloudflare account ID")
 	rootCmd.MarkPersistentFlagRequired(CfAPITokenFlag)
-	rootCmd.MarkPersistentFlagRequired(CfAccountIDFlag)
 }
 
 func newCfAPIClient(opts ...cloudflare.Option) (*cloudflare.API, error) {

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -14,4 +14,6 @@ var workerCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(workerCmd)
+	workerCmd.PersistentFlags().StringVar(&cfAccountIDFlag, CfAccountIDFlag, "", "Cloudflare account ID")
+	workerCmd.MarkPersistentFlagRequired(CfAccountIDFlag)
 }


### PR DESCRIPTION
Made it so the command is called with `cfwctl --cf-api-token <TOKEN> worker script list --cf-account-id <ID>`. The `--cf-api-token` flag is global but `--cf-account-id` is local to the `worker` subcommand.