### PR TITLE
Indent print JSON with a single space

### DIFF
--- a/cmd/worker_script.go
+++ b/cmd/worker_script.go
@@ -30,7 +30,7 @@ var workerScriptListCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("listing worker scripts: %s", err.Error())
 		}
-		b, err := json.Marshal(res.WorkerList)
+		b, err := json.MarshalIndent(res.WorkerList, "", " ")
 		if err != nil {
 			log.Fatalf("marshaling JSON: %s", err.Error())
 		}


### PR DESCRIPTION
This will print using https://golang.org/pkg/encoding/json/#MarshalIndent with a single space for indent.