### PR TITLE
Add a worker routes update command

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -4,5 +4,4 @@ const (
 	CfAPITokenFlag  = "cf-api-token"
 	CfAccountIDFlag = "cf-account-id"
 	CfZoneIDFlag    = "cf-zone-id"
-	EnabledFlag     = "enabled"
 )

--- a/cmd/worker_routes.go
+++ b/cmd/worker_routes.go
@@ -26,11 +26,7 @@ var workerRoutesCreateCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("creating new Cloudflare API client: %s", err.Error())
 		}
-		enabled, err := cmd.Flags().GetBool(EnabledFlag)
-		if err != nil {
-			log.Fatalf("reading %s flag: %s", EnabledFlag, err.Error())
-		}
-		route := cloudflare.WorkerRoute{Pattern: args[0], Enabled: enabled, Script: args[1]}
+		route := cloudflare.WorkerRoute{Pattern: args[0], Script: args[1]}
 		res, err := api.CreateWorkerRoute(cfZoneIDFlag, route)
 		if err != nil {
 			log.Fatalf("creating worker route: %s", err.Error())
@@ -87,12 +83,35 @@ var workerRoutesListCmd = &cobra.Command{
 	},
 }
 
+var workerRoutesUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "update worker route",
+	Long:  `Update a Worker route`,
+	Args:  cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		api, err := newCfAPIClient(cloudflare.UsingAccount(cfAccountIDFlag))
+		if err != nil {
+			log.Fatalf("creating new Cloudflare API client: %s", err.Error())
+		}
+		route := cloudflare.WorkerRoute{Pattern: args[1], Script: args[2]}
+		res, err := api.UpdateWorkerRoute(cfZoneIDFlag, args[0], route)
+		if err != nil {
+			log.Fatalf("updating worker route: %s", err.Error())
+		}
+		b, err := json.MarshalIndent(res, "", " ")
+		if err != nil {
+			log.Fatalf("marshaling JSON: %s", err.Error())
+		}
+		fmt.Printf("%s", b)
+	},
+}
+
 func init() {
 	workerCmd.AddCommand(workerRoutesCmd)
 	workerRoutesCmd.PersistentFlags().StringVar(&cfZoneIDFlag, CfZoneIDFlag, "", "Cloudflare zone ID")
 	workerRoutesCmd.MarkPersistentFlagRequired(CfZoneIDFlag)
 	workerRoutesCmd.AddCommand(workerRoutesCreateCmd)
-	workerRoutesCreateCmd.Flags().Bool(EnabledFlag, false, "Worker enabled")
 	workerRoutesCmd.AddCommand(workerRoutesDeleteCmd)
 	workerRoutesCmd.AddCommand(workerRoutesListCmd)
+	workerRoutesCmd.AddCommand(workerRoutesUpdateCmd)
 }


### PR DESCRIPTION
This adds a `worker routes update` command. The `enabled` flag was also removed for certain `worker routes` commands since that property only existed for the deprecated Worker API.