### PR TITLE
Add storage kv namespaces commands

### DIFF
--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// workerCmd represents the worker command
+var storageCmd = &cobra.Command{
+	Use:              "storage",
+	Short:            "storage commands",
+	Long:             `Storage commands that can be run`,
+	TraverseChildren: true,
+}
+
+func init() {
+	rootCmd.AddCommand(storageCmd)
+	storageCmd.PersistentFlags().StringVar(&cfAPITokenFlag, CfAPITokenFlag, "", "Cloudflare API token")
+	storageCmd.MarkPersistentFlagRequired(CfAPITokenFlag)
+	storageCmd.PersistentFlags().StringVar(&cfAccountIDFlag, CfAccountIDFlag, "", "Cloudflare account ID")
+	storageCmd.MarkPersistentFlagRequired(CfAccountIDFlag)
+}


### PR DESCRIPTION
This adds `storage kv namespaces` commands.

```
Namespaces commands that can be run

Usage:
  cfwctl storage kv namespaces [command]

Available Commands:
  create      create namespace
  delete      delete namespace
  list        list namespaces
  update      update namespace

Flags:
  -h, --help   help for namespaces

Global Flags:
      --cf-account-id string   Cloudflare account ID
      --cf-api-token string    Cloudflare API token

Use "cfwctl storage kv namespaces [command] --help" for more information about a command.
```