### PR TITLE
Add storage kv namespaces keys commands

### DIFF
--- a/cmd/storage_kv.go
+++ b/cmd/storage_kv.go
@@ -24,6 +24,13 @@ var namespacesCmd = &cobra.Command{
 	TraverseChildren: true,
 }
 
+var keysCmd = &cobra.Command{
+	Use:              "keys",
+	Short:            "keys commands",
+	Long:             `Keys commands that can be run`,
+	TraverseChildren: true,
+}
+
 var namespacesCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create namespace",
@@ -114,11 +121,100 @@ var namespacesUpdateCmd = &cobra.Command{
 	},
 }
 
+var keysDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "delete a key and value",
+	Long:  `Delete a Key and Value`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		api, err := newCfAPIClient(cloudflare.UsingAccount(cfAccountIDFlag))
+		if err != nil {
+			log.Fatalf("creating new Cloudflare API client: %s", err.Error())
+		}
+		res, err := api.DeleteWorkersKV(context.Background(), args[0], args[1])
+		if err != nil {
+			log.Fatalf("deleting a key and value: %s", err.Error())
+		}
+		b, err := json.MarshalIndent(res, "", " ")
+		if err != nil {
+			log.Fatalf("marshaling JSON: %s", err.Error())
+		}
+		fmt.Printf("%s", b)
+	},
+}
+
+var keysListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "list keys",
+	Long:  `Fetch a list of Keys`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		api, err := newCfAPIClient(cloudflare.UsingAccount(cfAccountIDFlag))
+		if err != nil {
+			log.Fatalf("creating new Cloudflare API client: %s", err.Error())
+		}
+		res, err := api.ListWorkersKVs(context.Background(), args[0])
+		if err != nil {
+			log.Fatalf("listing keys: %s", err.Error())
+		}
+		b, err := json.MarshalIndent(res.Result, "", " ")
+		if err != nil {
+			log.Fatalf("marshaling JSON: %s", err.Error())
+		}
+		fmt.Printf("%s", b)
+	},
+}
+
+var keysReadCmd = &cobra.Command{
+	Use:   "read",
+	Short: "read value for key",
+	Long:  `Read a Value for a Key`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		api, err := newCfAPIClient(cloudflare.UsingAccount(cfAccountIDFlag))
+		if err != nil {
+			log.Fatalf("creating new Cloudflare API client: %s", err.Error())
+		}
+		res, err := api.ReadWorkersKV(context.Background(), args[0], args[1])
+		if err != nil {
+			log.Fatalf("reading key: %s", err.Error())
+		}
+		fmt.Printf("%s", res)
+	},
+}
+
+var keysWriteCmd = &cobra.Command{
+	Use:   "write",
+	Short: "write value for key",
+	Long:  `Write a Value for a Key`,
+	Args:  cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		api, err := newCfAPIClient(cloudflare.UsingAccount(cfAccountIDFlag))
+		if err != nil {
+			log.Fatalf("creating new Cloudflare API client: %s", err.Error())
+		}
+		res, err := api.WriteWorkersKV(context.Background(), args[0], args[1], []byte(args[2]))
+		if err != nil {
+			log.Fatalf("writing value for a key: %s", err.Error())
+		}
+		b, err := json.MarshalIndent(res, "", " ")
+		if err != nil {
+			log.Fatalf("marshaling JSON: %s", err.Error())
+		}
+		fmt.Printf("%s", b)
+	},
+}
+
 func init() {
 	storageCmd.AddCommand(kvCmd)
 	kvCmd.AddCommand(namespacesCmd)
+	namespacesCmd.AddCommand(keysCmd)
 	namespacesCmd.AddCommand(namespacesCreateCmd)
 	namespacesCmd.AddCommand(namespacesDeleteCmd)
 	namespacesCmd.AddCommand(namespacesListCmd)
 	namespacesCmd.AddCommand(namespacesUpdateCmd)
+	keysCmd.AddCommand(keysDeleteCmd)
+	keysCmd.AddCommand(keysListCmd)
+	keysCmd.AddCommand(keysReadCmd)
+	keysCmd.AddCommand(keysWriteCmd)
 }


### PR DESCRIPTION
```
Keys commands that can be run

Usage:
  cfwctl storage kv namespaces keys [command]

Available Commands:
  delete      delete a key and value
  list        list keys
  read        read value for key
  write       write value for key

Flags:
  -h, --help   help for keys

Global Flags:
      --cf-account-id string   Cloudflare account ID
      --cf-api-token string    Cloudflare API token

Use "cfwctl storage kv namespaces keys [command] --help" for more information about a command.
```